### PR TITLE
chore: sync docker-compose.prod.yml with fx rate changes

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,12 @@ services:
       - VAULT_ADDR=${VAULT_ADDR:-http://shared-vault:8200}
       - VAULT_TOKEN=${VAULT_TOKEN}
       - VAULT_SECRET_PATH=${VAULT_SECRET_PATH:-secret/data/linguistnow/tokens}
+
+      # Redis Configuration (for FX rate caching)
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+
+      # Frankfurter Configuration (for ECB FX rates)
+      - FRANKFURTER_URL=${FRANKFURTER_URL:-http://frankfurter:8080}
     healthcheck:
       test:
         [
@@ -73,6 +79,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    depends_on:
+      redis:
+        condition: service_healthy
+      frankfurter:
+        condition: service_healthy
     networks:
       - shared_net
 
@@ -109,6 +120,44 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
+    networks:
+      - shared_net
+
+  # ---------------------------------------------------------------------------
+  # Redis (FX Rate Cache)
+  # ---------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: linguistnow-redis
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - shared_net
+
+  # ---------------------------------------------------------------------------
+  # Frankfurter (ECB FX Rates)
+  # ---------------------------------------------------------------------------
+  frankfurter:
+    image: frankfurter/frankfurter:latest
+    container_name: linguistnow-frankfurter
+    restart: unless-stopped
+    ports:
+      - "${FRANKFURTER_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/latest"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - shared_net
 
@@ -152,3 +201,7 @@ networks:
 #
 # Or use the full docker-compose.yml which builds from source.
 # =============================================================================
+
+volumes:
+  redis-data:
+    name: linguistnow-redis-data

--- a/docs/deployment/deploy-app-to-production.md
+++ b/docs/deployment/deploy-app-to-production.md
@@ -57,6 +57,8 @@ flowchart TB
         subgraph LinguistNow["📦 LinguistNow Stack"]
             Frontend["🌐 Frontend<br/>(Nginx)<br/>:3000<br/><br/>Includes:<br/>- React app<br/>- Shared types<br/>(bundled)"]
             Backend["⚙️ Backend<br/>(Node.js)<br/>:5000<br/><br/>Includes:<br/>- Express API<br/>- Shared types<br/>(built)"]
+            Redis["🗄️ Redis<br/>(FX Cache)<br/>:6379"]
+            Frankfurter["💱 Frankfurter<br/>(FX Rates)<br/>:8080"]
         end
     end
 
@@ -64,6 +66,8 @@ flowchart TB
     Backend <--> N8N
     Backend -->|Write Tokens| Vault
     N8N -->|Read Tokens<br/>via Community Node| Vault
+    Backend <--> Redis
+    Backend --> Frankfurter
 ```
 
 **Note**: The `@linguistnow/shared` package is a TypeScript library containing shared types and utilities. It is:
@@ -175,6 +179,10 @@ This deploys LinguistNow connecting to external Vault and n8n (deployed as prere
 
    # Vault (from prerequisite setup)
    VAULT_TOKEN=<token-from-vault-setup>
+
+   # FX Rates (Optional - defaults shown)
+   REDIS_URL=redis://redis:6379
+   FRANKFURTER_URL=http://frankfurter:8080
    ```
 
 6. Click **Deploy the stack**
@@ -228,6 +236,8 @@ Use this method if you need to build images from source with custom frontend URL
    AIRTABLE_BASE_ID=appxxxxx
    N8N_BASE_URL=http://n8n:5678
    VAULT_TOKEN=dev-token
+   REDIS_URL=redis://redis:6379
+   FRANKFURTER_URL=http://frankfurter:8080
    ```
 
 6. Click **Deploy the stack**


### PR DESCRIPTION
This PR updates `docker-compose.prod.yml` to reflect the changes made to `docker-compose.yml` in commit `eaadc708d51f5d657a7d1a2d38de5f47505c8f27`.

Added:
- Redis configuration and container for FX rate caching.
- Frankfurter configuration and container for ECB FX rates.
- `depends_on` clauses for the backend service.