### PR TITLE
fix: use correct frankfurter docker image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -147,7 +147,7 @@ services:
   # Frankfurter (ECB FX Rates)
   # ---------------------------------------------------------------------------
   frankfurter:
-    image: frankfurter/frankfurter:latest
+    image: lineofflight/frankfurter:latest
     container_name: linguistnow-frankfurter
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
   # Frankfurter (ECB FX Rates)
   # ---------------------------------------------------------------------------
   frankfurter:
-    image: frankfurter/frankfurter:latest
+    image: lineofflight/frankfurter:latest
     container_name: linguistnow-frankfurter
     restart: unless-stopped
     ports:

--- a/docs/integrations/frankfurter-setup.md
+++ b/docs/integrations/frankfurter-setup.md
@@ -10,7 +10,7 @@ Frankfurter is configured in `docker-compose.yml`:
 
 ```yaml
 frankfurter:
-  image: frankfurter/frankfurter:latest
+  image: lineofflight/frankfurter:latest
   container_name: linguistnow-frankfurter
   restart: unless-stopped
   ports:
@@ -210,7 +210,7 @@ curl http://localhost:8080/latest
 1. **Run Frankfurter locally:**
 
    ```bash
-   docker run -d -p 8080:8080 frankfurter/frankfurter:latest
+   docker run -d -p 8080:8080 lineofflight/frankfurter:latest
    ```
 
 2. **Update server/.env:**


### PR DESCRIPTION
Fixes the incorrect image name `frankfurter/frankfurter:latest` to `lineofflight/frankfurter:latest` across all docker-compose files and documentation.