### PR TITLE
fix(frankfurter): add data volume and increase healthcheck timeout

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -152,12 +152,14 @@ services:
     restart: unless-stopped
     ports:
       - "${FRANKFURTER_PORT:-8080}:8080"
+    volumes:
+      - frankfurter-data:/app/data
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/latest"]
       interval: 60s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 45m
     networks:
       - shared_net
 
@@ -205,3 +207,5 @@ networks:
 volumes:
   redis-data:
     name: linguistnow-redis-data
+  frankfurter-data:
+    name: linguistnow-frankfurter-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,12 +263,14 @@ services:
     restart: unless-stopped
     ports:
       - "${FRANKFURTER_PORT:-8080}:8080"
+    volumes:
+      - frankfurter-data:/app/data
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/latest"]
       interval: 60s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 45m
     networks:
       - linguistnow-net
     logging:
@@ -297,3 +299,5 @@ volumes:
     name: linguistnow-vault-logs
   redis-data:
     name: linguistnow-redis-data
+  frankfurter-data:
+    name: linguistnow-frankfurter-data


### PR DESCRIPTION
Based on analysis of frankfurter logs, the `linguistnow-frankfurter` container was getting trapped in a loop caused by a massive initial data sync, lack of persistent storage, and an impatient healthcheck timeout.

This PR fixes it by:
1. Adding a `frankfurter-data` volume to persist the downloaded SQLite database so the 20+ minute sync only ever has to happen once.
2. Increasing the `start_period` of the healthcheck to `45m` to give Docker enough breathing room to finish the initial backfill.

This applies to both `docker-compose.yml` and `docker-compose.prod.yml`.