### PR TITLE
fix(frankfurter): change healthcheck to use ruby instead of missing wget

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -155,7 +155,8 @@ services:
     volumes:
       - frankfurter-data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/latest"]
+      # Using Ruby's built-in net/http to check the endpoint since wget is missing
+      test: ["CMD-SHELL", "ruby -rnet/http -e 'res = Net::HTTP.get_response(URI(\"http://localhost:8080/latest\")); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)'"]
       interval: 60s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -266,7 +266,8 @@ services:
     volumes:
       - frankfurter-data:/app/data
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/latest"]
+      # Using Ruby's built-in net/http to check the endpoint since wget is missing
+      test: ["CMD-SHELL", "ruby -rnet/http -e 'res = Net::HTTP.get_response(URI(\"http://localhost:8080/latest\")); exit(res.is_a?(Net::HTTPSuccess) ? 0 : 1)'"]
       interval: 60s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
The `lineofflight/frankfurter:latest` image has been built using a slimmed-down Linux distribution that does not have the `wget` utility installed. This causes the Docker healthcheck to instantly fail, preventing dependent containers (like the backend) from starting.

This PR replaces the `wget` command in the `frankfurter` service healthcheck with a built-in Ruby `net/http` one-liner. Because the container runs on Ruby (`RUBY_VERSION=3.4.9`), this is guaranteed to work regardless of missing Linux utilities.

This applies to both `docker-compose.yml` and `docker-compose.prod.yml`.